### PR TITLE
Restrict GITHUB_TOKEN scope in workflows (least privilege)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [created]
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Adds explicit `permissions: contents: read` at the workflow root of `publish.yml` and `tests.yml`.
- Resolves CodeQL alerts `actions/missing-workflow-permissions` (#1, #2) flagged in org-wide GitHub Advanced Security scan.

## Why
Without an explicit `permissions:` block, the default `GITHUB_TOKEN` inherits whatever the repo/org-wide default is - historically `read-write` on older orgs. Both jobs only need to read the repo:
- `tests.yml`: checks out code and runs pytest
- `publish.yml`: checks out code and uploads to PyPI via `TWINE_USERNAME` / `TWINE_PASSWORD` secrets (independent of `GITHUB_TOKEN`)

## Test plan
- [ ] Confirm the Tests workflow still runs on this PR (it should - read-only is sufficient for checkout + pytest).
- [ ] After merge, cut a release and verify `publish.yml` still publishes to PyPI (TWINE secrets are unaffected by `GITHUB_TOKEN` scope).
- [ ] Verify the two CodeQL alerts auto-close.