### PR TITLE
feat: advanced pool search (/frontend/v1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to the DexPaprika SDK for Python will be documented in this 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **Advanced pool search**: `pools.advanced_search()` (alias `pools.search()`) wrapping the `/frontend/v1/pools` and `/frontend/v1/networks/{network}/pools` endpoints. Searches across all networks or one, with cursor pagination, canonical `sort_by`/`sort_dir` sorting (translated to the wire `order_by`/`sort`), price/volume/liquidity/dex filters, and an optional `detailed` mode that returns full token metadata plus per-timeframe metric blocks.
+- New Pydantic models: `PoolSearchResponse`, `PoolRow`, `SearchToken`, `TokenTimeframeMetrics`. Response fields are optional/nullable so a partial row or omitted field can't break deserialization.
+- Live tests covering the global and per-network variants, the sort translation, filtering, cursor pagination, and detailed token metrics
+
 ## [0.4.0] - 2026-03-31
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A Python client for the DexPaprika API. This SDK provides easy access to real-ti
 - Query information about DEXes, liquidity pools, and tokens
 - Get detailed price information, trading volume, and transactions
 - **Filter pools and tokens** by volume, liquidity, FDV, transactions, and creation date
+- **Advanced pool search** across all networks or one, with cursor pagination and detailed token metrics
 - **Get top tokens** on any network ranked by volume or other metrics
 - **Batch price lookups** for up to 10 tokens in a single request
 - Search across the entire DexPaprika ecosystem
@@ -177,6 +178,34 @@ filtered = client.pools.filter(
 for pool in filtered.results:
     token_pair = f"{pool.tokens[0].symbol}/{pool.tokens[1].symbol}" if len(pool.tokens) >= 2 else "Unknown"
     print(f"- {token_pair}: ${pool.volume_usd:,.0f} volume")
+```
+
+#### Advanced pool search (cursor pagination + detailed tokens)
+
+`advanced_search` (alias: `search`) wraps the `/frontend/v1` pool search. Pass
+`network` for a per-network search or omit it to search every chain at once. It
+sorts on the canonical `sort_by` / `sort_dir` names (translated to the wire
+`order_by` / `sort` for you) and uses cursor pagination rather than page numbers.
+
+```python
+# First page of high-priced Uniswap v3 pools on Ethereum, with full token data
+resp = client.pools.advanced_search(
+    network="ethereum",
+    dex_name="uniswap_v3",
+    price_usd_min=0.5,
+    sort_by="volume_usd_24h",   # sent on the wire as order_by
+    sort_dir="desc",            # sent on the wire as sort
+    detailed=True,              # tokens carry fdv + per-timeframe metrics
+    limit=10,
+)
+for pool in resp.results:
+    print(f"- {pool.id}: ${pool.volume_usd_24h:,.0f} 24h volume")
+
+# Cursor pagination: feed next_cursor back in to get the next page
+if resp.has_next_page:
+    next_page = client.pools.advanced_search(
+        network="ethereum", cursor=resp.next_cursor, limit=10
+    )
 ```
 
 #### Get top tokens on a network

--- a/dexpaprika_sdk/api/pools.py
+++ b/dexpaprika_sdk/api/pools.py
@@ -4,17 +4,25 @@ import warnings
 from .base import BaseAPI
 from ..models.pools import (
     PoolsResponse, PoolDetails, OHLCVRecord, TransactionsResponse,
-    PoolFilterResponse,
+    PoolFilterResponse, PoolSearchResponse,
 )
 
 
 class PoolsAPI(BaseAPI):
     """API service for pool-related endpoints."""
-    
+
     # Valid values for common parameters
     VALID_SORT_VALUES: Set[str] = {"asc", "desc"}
     VALID_ORDER_BY_VALUES: Set[str] = {"volume_usd", "price_usd", "transactions", "last_price_change_usd_24h", "created_at"}
     VALID_INTERVAL_VALUES: Set[str] = {"1m", "5m", "10m", "15m", "30m", "1h", "6h", "12h", "24h"}
+
+    # Sort fields accepted by the advanced search (/frontend/v1) endpoint. These
+    # differ from VALID_ORDER_BY_VALUES above, which belong to the older
+    # /networks/{id}/pools list.
+    VALID_SEARCH_SORT_BY_VALUES: Set[str] = {
+        "volume_usd_24h", "volume_usd_7d", "volume_usd_30d", "liquidity_usd",
+        "txns_24h", "price_usd", "price_change_percentage_24h", "created_at",
+    }
     
     def list(
         self, 
@@ -363,3 +371,110 @@ class PoolsAPI(BaseAPI):
             data['results'] = []
 
         return PoolFilterResponse(**data)
+
+    def advanced_search(
+        self,
+        network: Optional[str] = None,
+        limit: int = 10,
+        cursor: Optional[str] = None,
+        sort_by: str = "volume_usd_24h",
+        sort_dir: str = "desc",
+        detailed: bool = False,
+        volume_24h_min: Optional[float] = None,
+        volume_24h_max: Optional[float] = None,
+        volume_7d_min: Optional[float] = None,
+        volume_7d_max: Optional[float] = None,
+        liquidity_usd_min: Optional[float] = None,
+        liquidity_usd_max: Optional[float] = None,
+        txns_24h_min: Optional[int] = None,
+        price_usd_min: Optional[float] = None,
+        price_usd_max: Optional[float] = None,
+        price_change_percentage_24h_min: Optional[float] = None,
+        price_change_percentage_24h_max: Optional[float] = None,
+        dex_name: Optional[str] = None,
+        created_after: Optional[Union[int, str]] = None,
+        created_before: Optional[Union[int, str]] = None,
+    ) -> PoolSearchResponse:
+        """
+        Advanced pool search against the /frontend/v1 endpoints.
+
+        Hits ``/frontend/v1/pools`` when ``network`` is omitted, or
+        ``/frontend/v1/networks/{network}/pools`` when it's given. Unlike the
+        page-based ``filter()`` and ``list_by_network()`` methods, this endpoint
+        uses cursor pagination: when ``has_next_page`` is True, pass
+        ``next_cursor`` back in as ``cursor`` to fetch the next page.
+
+        Sorting uses the canonical ``sort_by`` / ``sort_dir`` names. The backend
+        wire format actually expects ``order_by`` (field) and ``sort``
+        (direction), so this method translates them for you. Don't pass the wire
+        names directly.
+
+        Args:
+            network: Network ID (e.g. "ethereum"). Omit to search across all networks.
+            limit: Number of pools to return.
+            cursor: Cursor from a previous response's ``next_cursor`` for the next page.
+            sort_by: Field to sort by. One of: volume_usd_24h, volume_usd_7d,
+                volume_usd_30d, liquidity_usd, txns_24h, price_usd,
+                price_change_percentage_24h, created_at. Sent on the wire as ``order_by``.
+            sort_dir: Sort direction, "asc" or "desc". Sent on the wire as ``sort``.
+            detailed: When True, each token carries full metadata (name, symbol,
+                fdv, ...) plus per-timeframe metric blocks.
+            volume_24h_min/max: Filter by 24h volume in USD.
+            volume_7d_min/max: Filter by 7d volume in USD.
+            liquidity_usd_min/max: Filter by liquidity in USD.
+            txns_24h_min: Minimum number of transactions in 24h.
+            price_usd_min/max: Filter by pool price in USD.
+            price_change_percentage_24h_min/max: Filter by 24h price change percentage.
+            dex_name: Restrict to a single DEX (e.g. "uniswap_v3").
+            created_after: Only pools created after this time (Unix timestamp or ISO-8601).
+            created_before: Only pools created before this time (Unix timestamp or ISO-8601).
+
+        Returns:
+            PoolSearchResponse with ``results``, ``has_next_page``,
+            ``next_cursor``, and ``query`` (the wire params the backend applied).
+
+        Raises:
+            ValueError: If any parameter is invalid.
+        """
+        self._validate_range("limit", limit, min_val=1, max_val=100)
+        self._validate_enum("sort_dir", sort_dir, self.VALID_SORT_VALUES)
+        self._validate_enum("sort_by", sort_by, self.VALID_SEARCH_SORT_BY_VALUES)
+
+        # Canonical -> wire: sort_by becomes order_by, sort_dir becomes sort.
+        params = {
+            "limit": limit,
+            "cursor": cursor,
+            "order_by": sort_by,
+            "sort": sort_dir,
+            "detailed": "true" if detailed else None,
+            "volume_24h_min": volume_24h_min,
+            "volume_24h_max": volume_24h_max,
+            "volume_7d_min": volume_7d_min,
+            "volume_7d_max": volume_7d_max,
+            "liquidity_usd_min": liquidity_usd_min,
+            "liquidity_usd_max": liquidity_usd_max,
+            "txns_24h_min": txns_24h_min,
+            "price_usd_min": price_usd_min,
+            "price_usd_max": price_usd_max,
+            "price_change_percentage_24h_min": price_change_percentage_24h_min,
+            "price_change_percentage_24h_max": price_change_percentage_24h_max,
+            "dex_name": dex_name,
+            "created_after": created_after,
+            "created_before": created_before,
+        }
+        params = self._clean_params(params)
+
+        if network:
+            endpoint = f"/frontend/v1/networks/{network}/pools"
+        else:
+            endpoint = "/frontend/v1/pools"
+
+        data = self._get(endpoint, params=params)
+
+        if 'results' not in data:
+            data['results'] = []
+
+        return PoolSearchResponse(**data)
+
+    # Convenient alias matching the canonical surface name.
+    search = advanced_search

--- a/dexpaprika_sdk/models/__init__.py
+++ b/dexpaprika_sdk/models/__init__.py
@@ -4,6 +4,7 @@ from .pools import (
     Token, Pool, PoolsResponse, TimeIntervalMetrics,
     PoolDetails, OHLCVRecord, Transaction, TransactionsResponse,
     FilteredPool, PoolFilterResponse,
+    TokenTimeframeMetrics, SearchToken, PoolRow, PoolSearchResponse,
 )
 from .tokens import (
     TokenSummary, TokenDetails, TopTokenTimeMetrics, TopToken,
@@ -23,6 +24,7 @@ __all__ = [
     "Token", "Pool", "PoolsResponse", "TimeIntervalMetrics",
     "PoolDetails", "OHLCVRecord", "Transaction", "TransactionsResponse",
     "FilteredPool", "PoolFilterResponse",
+    "TokenTimeframeMetrics", "SearchToken", "PoolRow", "PoolSearchResponse",
 
     # Tokens
     "TokenSummary", "TokenDetails",

--- a/dexpaprika_sdk/models/pools.py
+++ b/dexpaprika_sdk/models/pools.py
@@ -152,3 +152,113 @@ class FilteredPool(BaseModel):
 class PoolFilterResponse(PaginatedResponse[FilteredPool]):
     # pool filter response (uses 'results' key)
     results: List[FilteredPool] = Field(...)
+
+
+# --- Advanced pool search (/frontend/v1/pools) ---------------------------------
+#
+# These models back pools.advanced_search(). The frontend endpoint returns a
+# richer shape than the public /pools list: cursor pagination, per-timeframe
+# volume, and (with detailed=True) full token metadata plus per-timeframe metric
+# blocks. Every field below is optional/nullable on purpose: in basic mode a
+# token carries only id/chain/has_image, and even in detailed mode the API drops
+# fields like fdv on some tokens. Hard-requiring any of these is exactly the bug
+# that broke the #40 filter models, so we never do it here.
+
+
+class TokenTimeframeMetrics(BaseModel):
+    """Per-timeframe trading metrics for a token (detailed=True only).
+
+    Keyed in the response by timeframe ("1m", "5m", ... "24h"). All fields are
+    optional because the API may omit any of them; last_price_usd_change in
+    particular is frequently null.
+    """
+
+    volume_usd: Optional[float] = Field(None)
+    buys: Optional[int] = Field(None)
+    sells: Optional[int] = Field(None)
+    txns: Optional[int] = Field(None)
+    last_price_usd_change: Optional[float] = Field(None)
+
+
+class SearchToken(BaseModel):
+    """A token inside an advanced-search pool row.
+
+    In basic mode only id/chain/has_image are present. With detailed=True the
+    API adds name, symbol, decimals, supply/fdv, links, and the timeframe metric
+    blocks below. Unknown extra keys are tolerated so a backend addition can't
+    break deserialization.
+    """
+
+    id: Optional[str] = Field(None)
+    chain: Optional[str] = Field(None)
+    has_image: Optional[bool] = Field(None)
+
+    # detailed=True adds these
+    name: Optional[str] = Field(None)
+    symbol: Optional[str] = Field(None)
+    status: Optional[str] = Field(None)
+    decimals: Optional[int] = Field(None)
+    added_at: Optional[str] = Field(None)
+    total_supply: Optional[float] = Field(None)
+    fdv: Optional[float] = Field(None)
+    description: Optional[str] = Field(None)
+    website: Optional[str] = Field(None)
+
+    # per-timeframe metric blocks (detailed=True). Aliased because Python
+    # attributes cannot start with a digit.
+    minute1: Optional[TokenTimeframeMetrics] = Field(None, alias="1m")
+    minute5: Optional[TokenTimeframeMetrics] = Field(None, alias="5m")
+    minute15: Optional[TokenTimeframeMetrics] = Field(None, alias="15m")
+    minute30: Optional[TokenTimeframeMetrics] = Field(None, alias="30m")
+    hour1: Optional[TokenTimeframeMetrics] = Field(None, alias="1h")
+    hour6: Optional[TokenTimeframeMetrics] = Field(None, alias="6h")
+    hour24: Optional[TokenTimeframeMetrics] = Field(None, alias="24h")
+
+    model_config = ConfigDict(populate_by_name=True, extra="allow")
+
+
+class PoolRow(BaseModel):
+    """A single pool row from the advanced-search endpoint.
+
+    Unlike the public list (single flat volume_usd) this row carries volume split
+    by timeframe (24h/7d/30d), liquidity, and 5m/1h/24h price-change percentages.
+    Only id is treated as effectively always present; everything else is optional
+    so a partial row never breaks the whole response.
+    """
+
+    id: str = Field(...)
+    dex_id: Optional[str] = Field(None)
+    dex_name: Optional[str] = Field(None)
+    chain: Optional[str] = Field(None)
+    fee: Optional[float] = Field(None)
+    created_at: Optional[str] = Field(None)
+    created_at_block_number: Optional[int] = Field(None)
+    price_usd: Optional[float] = Field(None)
+    transactions_24h: Optional[int] = Field(None)
+    volume_usd_24h: Optional[float] = Field(None)
+    volume_usd_7d: Optional[float] = Field(None)
+    volume_usd_30d: Optional[float] = Field(None)
+    liquidity_usd: Optional[float] = Field(None)
+    price_change_percentage_5m: Optional[float] = Field(None)
+    price_change_percentage_1h: Optional[float] = Field(None)
+    price_change_percentage_24h: Optional[float] = Field(None)
+    tokens: List[SearchToken] = Field(default_factory=list)
+
+    model_config = ConfigDict(extra="allow")
+
+
+class PoolSearchResponse(BaseModel):
+    """Response from the advanced pool search endpoint.
+
+    Cursor-paginated: when has_next_page is True, pass next_cursor back as the
+    ``cursor`` argument to fetch the next page (this endpoint is NOT page-based).
+    ``query`` echoes the wire params the backend actually applied (order_by/sort),
+    so it is kept as a permissive dict rather than a typed model.
+    """
+
+    results: List[PoolRow] = Field(default_factory=list)
+    has_next_page: Optional[bool] = Field(None)
+    next_cursor: Optional[str] = Field(None)
+    query: Optional[Dict[str, Any]] = Field(None)
+
+    model_config = ConfigDict(extra="allow")

--- a/tests/test_advanced_search.py
+++ b/tests/test_advanced_search.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""Live tests for the advanced pool search (/frontend/v1) endpoint.
+
+These hit the real API, in the same style as test_all_endpoints.py. They cover
+the global and per-network variants, cursor pagination, the canonical->wire sort
+translation (sort_by/sort_dir -> order_by/sort), filters, and the detailed token
+metadata + per-timeframe metric blocks.
+"""
+
+import sys
+import os
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '.')))
+
+from dexpaprika_sdk import DexPaprikaClient
+
+
+@pytest.fixture
+def client():
+    return DexPaprikaClient()
+
+
+@pytest.fixture
+def test_data():
+    return {
+        "ethereum_network": "ethereum",
+        "test_dex": "uniswap_v3",
+    }
+
+
+def test_advanced_search_global(client):
+    """Global search returns a non-empty, cursor-paginated result set."""
+    resp = client.pools.advanced_search(limit=5)
+    assert resp is not None
+    assert hasattr(resp, "results")
+    assert hasattr(resp, "has_next_page")
+    assert hasattr(resp, "next_cursor")
+    assert hasattr(resp, "query")
+    assert len(resp.results) > 0
+    row = resp.results[0]
+    assert row.id
+    assert hasattr(row, "volume_usd_24h")
+    assert hasattr(row, "tokens")
+
+
+def test_advanced_search_by_network(client, test_data):
+    """Per-network search hits /frontend/v1/networks/{network}/pools."""
+    resp = client.pools.advanced_search(
+        network=test_data["ethereum_network"], limit=5
+    )
+    assert resp is not None
+    assert len(resp.results) > 0
+    # The query echo reports the network the backend applied.
+    assert resp.query.get("network") == test_data["ethereum_network"]
+    for row in resp.results:
+        assert row.chain == test_data["ethereum_network"]
+
+
+def test_advanced_search_sort_translation(client, test_data):
+    """Canonical sort_by/sort_dir must be sent on the wire as order_by/sort."""
+    resp = client.pools.advanced_search(
+        network=test_data["ethereum_network"],
+        sort_by="volume_usd_24h",
+        sort_dir="desc",
+        limit=10,
+    )
+    assert resp is not None
+    # The wire param names show up in the echoed query, proving translation.
+    assert resp.query.get("order_by") == "volume_usd_24h"
+    assert resp.query.get("sort") == "desc"
+    assert "sort_by" not in resp.query
+    assert "sort_dir" not in resp.query
+    # And the results actually come back sorted descending by 24h volume.
+    volumes = [r.volume_usd_24h for r in resp.results if r.volume_usd_24h is not None]
+    assert volumes == sorted(volumes, reverse=True)
+
+
+def test_advanced_search_filter_works(client, test_data):
+    """A price + dex filter narrows the result set to matching pools."""
+    resp = client.pools.advanced_search(
+        network=test_data["ethereum_network"],
+        price_usd_min=0.5,
+        dex_name=test_data["test_dex"],
+        limit=10,
+    )
+    assert resp is not None
+    assert len(resp.results) > 0
+    for row in resp.results:
+        assert row.dex_id == test_data["test_dex"]
+        if row.price_usd is not None:
+            assert row.price_usd >= 0.5
+
+
+def test_advanced_search_cursor_pagination(client):
+    """next_cursor advances the window to a different second page.
+
+    We don't require fully disjoint pages: this is a live, high-volume feed and
+    rankings shift slightly between calls, so a pool sitting on the page boundary
+    can surface in both. What we assert is that the cursor genuinely moves the
+    window forward, i.e. the two pages are not identical.
+    """
+    first = client.pools.advanced_search(limit=3)
+    assert first.has_next_page is True
+    assert first.next_cursor
+    second = client.pools.advanced_search(limit=3, cursor=first.next_cursor)
+    assert second is not None
+    assert len(second.results) > 0
+    first_ids = [r.id for r in first.results]
+    second_ids = [r.id for r in second.results]
+    assert first_ids != second_ids
+    # The second page should surface at least one pool the first did not.
+    assert set(second_ids) - set(first_ids)
+
+
+def test_advanced_search_detailed_tokens(client, test_data):
+    """detailed=True enriches tokens with metadata and timeframe metric blocks."""
+    resp = client.pools.advanced_search(
+        network=test_data["ethereum_network"],
+        detailed=True,
+        limit=5,
+    )
+    assert resp is not None
+    assert len(resp.results) > 0
+    # Find a token that came back enriched (the API may omit some fields, so we
+    # look across rows rather than hard-requiring any single token).
+    enriched = [
+        t
+        for row in resp.results
+        for t in row.tokens
+        if t.symbol is not None
+    ]
+    assert enriched, "expected at least one detailed token with a symbol"
+    token = enriched[0]
+    assert token.id
+    assert token.decimals is not None
+    # At least one timeframe metric block should be populated.
+    blocks = [
+        t.hour24
+        for row in resp.results
+        for t in row.tokens
+        if t.hour24 is not None
+    ]
+    assert blocks, "expected at least one 24h timeframe metric block"
+
+
+def test_advanced_search_basic_tokens_minimal(client, test_data):
+    """Without detailed, tokens carry only the minimal id/chain shape."""
+    resp = client.pools.advanced_search(
+        network=test_data["ethereum_network"], limit=3
+    )
+    assert resp is not None
+    assert len(resp.results) > 0
+    token = resp.results[0].tokens[0]
+    assert token.id
+    # Basic mode does not populate symbol; this must not raise.
+    assert token.symbol is None
+
+
+def test_advanced_search_invalid_sort_by(client):
+    """An unknown sort_by is rejected before any request is made."""
+    with pytest.raises(ValueError):
+        client.pools.advanced_search(sort_by="not_a_field")
+
+
+def test_advanced_search_alias_method(client):
+    """pools.search is an alias for pools.advanced_search."""
+    assert client.pools.search == client.pools.advanced_search
+    resp = client.pools.search(limit=2)
+    assert resp is not None
+    assert len(resp.results) > 0
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## What this adds

`pools.advanced_search()` (alias `pools.search()`) wrapping the `/frontend/v1` pool search:

- `GET /frontend/v1/pools` when `network` is omitted (search across every chain)
- `GET /frontend/v1/networks/{network}/pools` when `network` is passed

This endpoint gives us cursor pagination and much richer pool/token data than the older `/networks/{id}/pools` list, so I wired it up as its own method rather than overloading `filter()`.

## Surface

I kept our canonical `sort_by` / `sort_dir` names and translate them to the wire names `order_by` / `sort` inside the method. That mapping is the inverse of what you'd guess, so it's the one thing I made sure to test directly (`test_advanced_search_sort_translation` asserts the echoed `query` reports `order_by`/`sort` and never leaks `sort_by`/`sort_dir`).

```python
resp = client.pools.advanced_search(
    network="ethereum",
    dex_name="uniswap_v3",
    price_usd_min=0.5,
    sort_by="volume_usd_24h",   # -> order_by on the wire
    sort_dir="desc",            # -> sort on the wire
    detailed=True,              # tokens carry fdv + 1m..24h metric blocks
    limit=10,
)
for pool in resp.results:
    print(pool.id, pool.volume_usd_24h)

if resp.has_next_page:
    page2 = client.pools.advanced_search(network="ethereum", cursor=resp.next_cursor, limit=10)
```

Pagination is cursor-based, not page-based: feed `next_cursor` back in as `cursor`.

## Models

New Pydantic models: `PoolSearchResponse`, `PoolRow`, `SearchToken`, `TokenTimeframeMetrics`.

Every response field is optional/nullable on purpose. In basic mode a token is just `id`/`chain`/`has_image`, and even with `detailed=True` the API drops fields like `fdv` on some tokens. The models also allow extra keys so a backend addition can't break deserialization. This is the same trap that bit the earlier filter models when fields were hard-required.

## Verification

- `pip install -e .` in a clean venv (pydantic 2.13)
- New live tests in `tests/test_advanced_search.py`, run against the live API, all 9 green: global + per-network variants, the sort translation, a price+dex filter, cursor pagination, detailed token metrics, the basic-token minimal shape, invalid-`sort_by` validation, and the `search` alias.
- Existing mocked suites (`test_features.py`, `test_validation.py`) still pass.

I did not merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)