### PR TITLE
Fix 410s: migrate pool/token list+filter methods to /search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,47 @@ All notable changes to the DexPaprika SDK for Python will be documented in this 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - 2026-06-30
+
+### Breaking Changes
+- **API endpoints removed (410 Gone)**: `/networks/{network}/pools`,
+  `/networks/{network}/pools/filter`, `/networks/{network}/tokens/top` and
+  `/networks/{network}/tokens/filter` were removed by DexPaprika. The SDK now
+  uses the unified `/networks/{network}/pools/search` and
+  `/networks/{network}/tokens/search` endpoints.
+- **Response shape changed**: `pools.list_by_network()`, `pools.list()`,
+  `pools.filter()`, `tokens.get_top()` and `tokens.filter()` now return
+  cursor-paginated responses with rows under `results` plus `has_next_page` and
+  `next_cursor` (no more `page_info`). `.pools` / `.tokens` remain as
+  backward-compatible aliases for `.results`.
+- **Item fields changed**: pool items use `id` (pool address), `volume_usd_24h`,
+  `volume_usd_7d`, `volume_usd_30d`, `liquidity_usd`, `transactions_24h`,
+  `price_usd`, `price_change_percentage_5m/1h/24h`. Token items are flat and use
+  `address`, `price_usd`, `volume_usd_24h/7d/30d`, `liquidity_usd`, `fdv_usd`,
+  `txns_24h`, `price_change_percentage_24h` (no `name`/`symbol`, no nested time
+  metrics).
+- Removed `TopTokenTimeMetrics` (no analog in the flat search shape).
+
+### Changed
+- Method signatures are unchanged for backward compatibility. Legacy `order_by` /
+  `sort_by` values (e.g. `volume_usd`, `volume_24h`, `transactions`, `fdv`) and
+  legacy filter param names (e.g. `volume_24h_min`) are mapped to the canonical
+  search names automatically; unknown sort fields fall back to `volume_usd_24h`.
+- `page` is still accepted but ignored (the search endpoints are cursor-based); a
+  new optional `cursor` parameter was added to the migrated methods.
+- `order_by` is no longer validated against a fixed enum (unknown values map to a
+  default instead of raising).
+- New Pydantic models: `PoolSearchToken`, `PoolSearchResult`, `PoolSearchResponse`,
+  `TokenSearchResult`, `TokenSearchResponse`. `FilteredPool`, `PoolFilterResponse`,
+  `TopToken`, `TopTokensResponse`, `FilteredToken` and `TokenFilterResponse` are
+  retained as aliases of the new models.
+- Updated SDK version to 0.5.0 and the user agent string.
+
+### Unchanged
+- DEX pools (`dexes`/`pools.list_by_dex`), pool detail, OHLCV, transactions, token
+  pools, token detail, multi/prices, search, networks, dexes and stats endpoints
+  are untouched.
+
 ## [0.4.0] - 2026-03-31
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -33,6 +33,43 @@ cd dexpaprika-sdk-python
 pip install -e .
 ```
 
+## Migration Guide (v0.5.0)
+
+**Important:** DexPaprika removed four REST endpoints (they now return `410 Gone`)
+and replaced them with unified search endpoints. The SDK was repointed
+accordingly:
+
+- `pools.list_by_network()` and `pools.filter()` now call `/networks/{network}/pools/search`
+- `tokens.get_top()` and `tokens.filter()` now call `/networks/{network}/tokens/search`
+
+Method signatures are unchanged (your existing `order_by` / `sort_by` / `sort_dir`
+values keep working; legacy sort fields and filter names are mapped to the new
+canonical ones automatically). What changed is the response shape:
+
+- Responses now expose rows under `results` (with `has_next_page` and `next_cursor`)
+  instead of `pools` / `tokens` / `page_info`. The old `.pools` / `.tokens`
+  attributes remain as backward-compatible aliases for `.results`.
+- Pagination is cursor-based. `page` is still accepted for backward compatibility
+  but is ignored; pass `cursor=...` to page through results.
+- Pool items: `id` is the pool address, volume is split into
+  `volume_usd_24h` / `volume_usd_7d` / `volume_usd_30d`, transactions are
+  `transactions_24h`, and price moves are `price_change_percentage_5m/1h/24h`.
+- Token items are flat and identified by `address` (no `name`/`symbol`, no nested
+  time-interval objects): `price_usd`, `volume_usd_24h/7d/30d`, `liquidity_usd`,
+  `fdv_usd`, `txns_24h`, `price_change_percentage_24h`.
+
+```python
+# Before:
+pools = client.pools.list_by_network("ethereum")
+for p in pools.pools:
+    print(p.volume_usd)
+
+# After:
+pools = client.pools.list_by_network("ethereum")
+for p in pools.results:          # .pools still works as an alias
+    print(p.volume_usd_24h)
+```
+
 ## Migration Guide (v0.3.0)
 
 **Important:** Version 0.3.0 includes breaking changes due to DexPaprika API v1.3.0 updates.
@@ -98,13 +135,13 @@ print(f"DexPaprika stats: {stats.chains} chains, {stats.pools} pools")
 # Get top pools by volume (network-specific)
 pools = client.pools.list_by_network(
     network_id="ethereum",
-    limit=5, 
-    order_by="volume_usd", 
+    limit=5,
+    order_by="volume_usd_24h",
     sort="desc"
 )
-for pool in pools.pools:
+for pool in pools.results:
     token_pair = f"{pool.tokens[0].symbol}/{pool.tokens[1].symbol}" if len(pool.tokens) >= 2 else "Unknown Pair"
-    print(f"- {token_pair} on {pool.dex_name} ({pool.chain}): ${pool.volume_usd:.2f} volume")
+    print(f"- {token_pair} on {pool.dex_name} ({pool.chain}): ${pool.volume_usd_24h or 0:,.2f} volume")
 ```
 
 ### Advanced Examples
@@ -114,11 +151,12 @@ for pool in pools.pools:
 ```python
 # Get top Ethereum pools
 eth_pools = client.pools.list_by_network(
-    network_id="ethereum", 
-    limit=5, 
-    order_by="volume_usd", 
+    network_id="ethereum",
+    limit=5,
+    order_by="volume_usd_24h",
     sort="desc"
 )
+# Rows are under `results`; pagination is cursor-based (has_next_page / next_cursor)
 ```
 
 #### Get pools for a specific DEX
@@ -176,16 +214,18 @@ filtered = client.pools.filter(
 )
 for pool in filtered.results:
     token_pair = f"{pool.tokens[0].symbol}/{pool.tokens[1].symbol}" if len(pool.tokens) >= 2 else "Unknown"
-    print(f"- {token_pair}: ${pool.volume_usd:,.0f} volume")
+    print(f"- {token_pair}: ${pool.volume_usd_24h or 0:,.0f} volume")
 ```
 
 #### Get top tokens on a network
 
 ```python
 # Get top tokens by volume on Ethereum
+# The flat search shape identifies a token by `address` (no name/symbol); rows
+# are under `results`.
 top = client.tokens.get_top("ethereum", order_by="volume_24h", limit=5)
-for token in top.tokens:
-    print(f"- {token.symbol}: ${token.price_usd:.4f} (24h vol: ${token.day.volume_usd:,.0f})")
+for token in top.results:
+    print(f"- {token.address}: ${token.price_usd or 0:.4f} (24h vol: ${token.volume_usd_24h or 0:,.0f})")
 ```
 
 #### Filter tokens by criteria
@@ -199,7 +239,7 @@ filtered = client.tokens.filter(
     limit=10
 )
 for token in filtered.results:
-    print(f"- {token.address}: ${token.volume_usd_24h:,.0f} vol, ${token.fdv_usd:,.0f} FDV")
+    print(f"- {token.address}: ${token.volume_usd_24h or 0:,.0f} vol, ${token.fdv_usd or 0:,.0f} FDV")
 ```
 
 #### Get batch prices for multiple tokens

--- a/dexpaprika_sdk/__init__.py
+++ b/dexpaprika_sdk/__init__.py
@@ -16,25 +16,29 @@ from .models import (
     Network, Dex, DexesResponse,
     Token, Pool, PoolsResponse, TimeIntervalMetrics,
     PoolDetails, OHLCVRecord, Transaction, TransactionsResponse,
+    PoolSearchToken, PoolSearchResult, PoolSearchResponse,
     FilteredPool, PoolFilterResponse,
     TokenSummary, TokenDetails,
-    TopTokenTimeMetrics, TopToken, TopTokensResponse,
-    FilteredToken, TokenFilterResponse, TokenPrice,
+    TokenSearchResult, TokenSearchResponse,
+    TopToken, TopTokensResponse, FilteredToken, TokenFilterResponse,
+    TokenPrice,
     DexInfo, SearchResult,
     Stats
 )
 
-__version__ = "0.4.0"
+__version__ = "0.5.0"
 __all__ = [
     "DexPaprikaClient",
     # Models
     "Network", "Dex", "DexesResponse",
     "Token", "Pool", "PoolsResponse", "TimeIntervalMetrics",
     "PoolDetails", "OHLCVRecord", "Transaction", "TransactionsResponse",
+    "PoolSearchToken", "PoolSearchResult", "PoolSearchResponse",
     "FilteredPool", "PoolFilterResponse",
     "TokenSummary", "TokenDetails",
-    "TopTokenTimeMetrics", "TopToken", "TopTokensResponse",
-    "FilteredToken", "TokenFilterResponse", "TokenPrice",
+    "TokenSearchResult", "TokenSearchResponse",
+    "TopToken", "TopTokensResponse", "FilteredToken", "TokenFilterResponse",
+    "TokenPrice",
     "DexInfo", "SearchResult",
     "Stats",
 ]

--- a/dexpaprika_sdk/api/base.py
+++ b/dexpaprika_sdk/api/base.py
@@ -8,6 +8,103 @@ if TYPE_CHECKING:
 
 T = TypeVar('T')
 
+
+# ---------------------------------------------------------------------------
+# Unified search endpoint mappings
+#
+# DexPaprika removed the legacy /pools, /pools/filter, /tokens/top and
+# /tokens/filter endpoints (now HTTP 410) in favour of /pools/search and
+# /tokens/search. The search endpoints return HTTP 400 for the old sort-field
+# values and the old filter param names, so everything must be mapped to the
+# canonical names below. These are small, pure helpers shared by the pools and
+# tokens API services.
+# ---------------------------------------------------------------------------
+
+# Sort-field values accepted as-is by /pools/search.
+POOL_SORT_CANONICAL: Set[str] = {
+    "volume_usd_24h", "volume_usd_7d", "volume_usd_30d", "liquidity_usd",
+    "txns_24h", "created_at", "price_usd", "price_change_percentage_24h",
+}
+
+# Legacy sort-field value -> canonical /pools/search value.
+POOL_SORT_FIELD_MAP: Dict[str, str] = {
+    "volume_usd": "volume_usd_24h",
+    "transactions": "txns_24h",
+    "last_price_change_usd_24h": "price_change_percentage_24h",
+    "volume_24h": "volume_usd_24h",
+    "volume_7d": "volume_usd_7d",
+    "volume_30d": "volume_usd_30d",
+    "liquidity": "liquidity_usd",
+}
+
+# Sort-field values accepted as-is by /tokens/search.
+TOKEN_SORT_CANONICAL: Set[str] = {
+    "volume_usd_24h", "volume_usd_7d", "volume_usd_30d", "liquidity_usd",
+    "txns_24h", "fdv_usd", "created_at", "price_change_percentage_24h",
+}
+
+# Legacy sort-field value -> canonical /tokens/search value.
+# Note: /tokens/search returns 400 when ordering by price, so price_usd falls
+# back to volume_usd_24h.
+TOKEN_SORT_FIELD_MAP: Dict[str, str] = {
+    "volume_24h": "volume_usd_24h",
+    "txns": "txns_24h",
+    "price_change": "price_change_percentage_24h",
+    "fdv": "fdv_usd",
+    "volume_7d": "volume_usd_7d",
+    "volume_30d": "volume_usd_30d",
+    "price_usd": "volume_usd_24h",
+}
+
+# Legacy filter param name -> canonical /pools/search query param name.
+# Names not listed here (liquidity_usd_min, liquidity_usd_max, txns_24h_min,
+# created_after, created_before) are already canonical and pass through.
+POOL_FILTER_PARAM_MAP: Dict[str, str] = {
+    "volume_24h_min": "volume_usd_24h_min",
+    "volume_24h_max": "volume_usd_24h_max",
+    "volume_7d_min": "volume_usd_7d_min",
+    "volume_7d_max": "volume_usd_7d_max",
+}
+
+# Legacy filter param name -> canonical /tokens/search query param name.
+# Names not listed here (liquidity_usd_min, fdv_min, fdv_max, txns_24h_min,
+# created_after, created_before) are already canonical and pass through.
+TOKEN_FILTER_PARAM_MAP: Dict[str, str] = {
+    "volume_24h_min": "volume_usd_24h_min",
+    "volume_24h_max": "volume_usd_24h_max",
+}
+
+
+def map_pool_sort_field(value: Optional[str]) -> str:
+    """Map a (possibly legacy) pool sort field to the canonical search value.
+
+    Canonical values pass through unchanged; known legacy values are translated;
+    anything unknown falls back to the default ``volume_usd_24h``.
+    """
+    if value in POOL_SORT_CANONICAL:
+        return value
+    return POOL_SORT_FIELD_MAP.get(value, "volume_usd_24h")
+
+
+def map_token_sort_field(value: Optional[str]) -> str:
+    """Map a (possibly legacy) token sort field to the canonical search value.
+
+    Canonical values pass through unchanged; known legacy values are translated;
+    anything unknown falls back to the default ``volume_usd_24h``.
+    """
+    if value in TOKEN_SORT_CANONICAL:
+        return value
+    return TOKEN_SORT_FIELD_MAP.get(value, "volume_usd_24h")
+
+
+def map_filter_params(filters: Dict[str, Any], name_map: Dict[str, str]) -> Dict[str, Any]:
+    """Rename legacy filter param keys to their canonical search names.
+
+    Keys absent from ``name_map`` are already canonical and pass through. Values
+    are left untouched (None values are dropped later by ``_clean_params``).
+    """
+    return {name_map.get(key, key): value for key, value in filters.items()}
+
 class CacheEntry:
     """Class representing a cached response with an expiration time."""
     

--- a/dexpaprika_sdk/api/pools.py
+++ b/dexpaprika_sdk/api/pools.py
@@ -1,52 +1,58 @@
 from typing import List, Optional, Dict, Any, Set, Union
 import warnings
 
-from .base import BaseAPI
+from .base import BaseAPI, map_pool_sort_field, map_filter_params, POOL_FILTER_PARAM_MAP
 from ..models.pools import (
     PoolsResponse, PoolDetails, OHLCVRecord, TransactionsResponse,
-    PoolFilterResponse,
+    PoolSearchResponse,
 )
 
 
 class PoolsAPI(BaseAPI):
     """API service for pool-related endpoints."""
-    
+
     # Valid values for common parameters
     VALID_SORT_VALUES: Set[str] = {"asc", "desc"}
+    # order_by for the still-valid DEX pools endpoint (/dexes/{dex}/pools).
     VALID_ORDER_BY_VALUES: Set[str] = {"volume_usd", "price_usd", "transactions", "last_price_change_usd_24h", "created_at"}
     VALID_INTERVAL_VALUES: Set[str] = {"1m", "5m", "10m", "15m", "30m", "1h", "6h", "12h", "24h"}
     
     def list(
-        self, 
-        page: int = 0, 
-        limit: int = 10, 
-        sort: str = "desc", 
-        order_by: str = "volume_usd"
-    ) -> PoolsResponse:
+        self,
+        page: int = 0,
+        limit: int = 10,
+        sort: str = "desc",
+        order_by: str = "volume_usd",
+        cursor: Optional[str] = None,
+    ) -> PoolSearchResponse:
         """
         DEPRECATED: Get a list of top pools across all networks.
-        
-        This method is deprecated due to API changes. The global /pools endpoint 
+
+        This method is deprecated due to API changes. The global /pools endpoint
         has been removed. Use list_by_network(network_id, ...) instead.
-        
-        For backward compatibility, this method now defaults to Ethereum network.
-        
+
+        For backward compatibility, this method now defaults to the Ethereum
+        network (via /networks/ethereum/pools/search).
+
         Args:
-            page: Page number for pagination
+            page: Accepted for backward compatibility. The search endpoint is
+                cursor-paginated, so this value is ignored for the request.
             limit: Number of items per page
             sort: Sort order ("asc" or "desc")
-            order_by: Field to order by ("volume_usd", "price_usd", etc.)
-            
+            order_by: Field to order by (legacy values such as "volume_usd" are
+                mapped to canonical search fields automatically)
+            cursor: Cursor for cursor-based pagination
+
         Returns:
-            Response containing a list of pools
-            
+            Cursor-paginated pool search response
+
         Raises:
             ValueError: If any parameter is invalid
-            
+
         Migration Examples:
             # Before (deprecated):
             pools = client.pools.list()
-            
+
             # After (recommended):
             pools = client.pools.list_by_network('ethereum')
             pools = client.pools.list_by_network('solana')
@@ -54,63 +60,43 @@ class PoolsAPI(BaseAPI):
         # Issue deprecation warning
         warnings.warn(
             "The pools.list() method is deprecated. The global /pools endpoint has been "
-            "removed in API v1.3.0. Use pools.list_by_network(network_id) instead. "
-            "This method now defaults to Ethereum network for backward compatibility. "
+            "removed. Use pools.list_by_network(network_id) instead. "
+            "This method now defaults to the Ethereum network for backward compatibility. "
             "Examples: client.pools.list_by_network('ethereum'), "
             "client.pools.list_by_network('solana')",
             DeprecationWarning,
             stacklevel=2
         )
-        
-        # Validate parameters
-        self._validate_range("page", page, min_val=0)
-        self._validate_range("limit", limit, min_val=1, max_val=100)
-        self._validate_enum("sort", sort, self.VALID_SORT_VALUES)
-        self._validate_enum("order_by", order_by, self.VALID_ORDER_BY_VALUES)
-        
-        try:
-            # Attempt to call the deprecated endpoint first for debugging/testing
-            params = {"page": page, "limit": limit, "sort": sort, "order_by": order_by}
-            data = self._get("/pools", params=params)
-            
-            # ensure pools exists
-            if 'pools' not in data: data['pools'] = []
-                
-            return PoolsResponse(**data)
-            
-        except Exception as e:
-            # If we get a 410 Gone or any other error, fall back to Ethereum
-            # Check if it's a 410 Gone status specifically
-            if hasattr(e, 'response') and hasattr(e.response, 'status_code') and e.response.status_code == 410:
-                # Provide a more specific error message for 410 Gone
-                print("WARNING: The global /pools endpoint has been permanently removed (410 Gone). "
-                      "Falling back to Ethereum network. Please update your code to use "
-                      "pools.list_by_network(network_id) instead.")
-            
-            # Fall back to Ethereum network for backward compatibility
-            return self.list_by_network("ethereum", page=page, limit=limit, sort=sort, order_by=order_by)
-    
+
+        return self.list_by_network(
+            "ethereum", page=page, limit=limit, sort=sort, order_by=order_by, cursor=cursor
+        )
+
     def list_by_network(
-        self, 
-        network_id: str, 
-        page: int = 0, 
-        limit: int = 10, 
-        sort: str = "desc", 
-        order_by: str = "volume_usd"
-    ) -> PoolsResponse:
+        self,
+        network_id: str,
+        page: int = 0,
+        limit: int = 10,
+        sort: str = "desc",
+        order_by: str = "volume_usd",
+        cursor: Optional[str] = None,
+    ) -> PoolSearchResponse:
         """
-        Get a list of pools on a specific network.
-        
+        Get a list of pools on a specific network via /pools/search.
+
         Args:
             network_id: Network ID (e.g., "ethereum", "solana")
-            page: Page number for pagination
+            page: Accepted for backward compatibility. The search endpoint is
+                cursor-paginated, so this value is ignored for the request.
             limit: Number of items per page
             sort: Sort order ("asc" or "desc")
-            order_by: Field to order by ("volume_usd", "price_usd", etc.)
-            
+            order_by: Field to order by (legacy values such as "volume_usd" are
+                mapped to canonical search fields automatically)
+            cursor: Cursor for cursor-based pagination
+
         Returns:
-            Response containing a list of pools
-            
+            Cursor-paginated pool search response
+
         Raises:
             ValueError: If any parameter is invalid
         """
@@ -119,16 +105,23 @@ class PoolsAPI(BaseAPI):
         self._validate_range("page", page, min_val=0)
         self._validate_range("limit", limit, min_val=1, max_val=100)
         self._validate_enum("sort", sort, self.VALID_SORT_VALUES)
-        self._validate_enum("order_by", order_by, self.VALID_ORDER_BY_VALUES)
-        
-        # Get network pools
-        params = {"page": page, "limit": limit, "sort": sort, "order_by": order_by}
-        data = self._get(f"/networks/{network_id}/pools", params=params)
-        
-        # ensure pools exists
-        if 'pools' not in data: data['pools'] = []
-            
-        return PoolsResponse(**data)
+
+        # Build the cursor-based search request with canonical names.
+        params = {
+            "limit": limit,
+            "order_by": map_pool_sort_field(order_by),
+            "sort": sort,
+            "cursor": cursor,
+        }
+        params = self._clean_params(params)
+
+        data = self._get(f"/networks/{network_id}/pools/search", params=params)
+
+        # ensure results exists
+        if 'results' not in data:
+            data['results'] = []
+
+        return PoolSearchResponse(**data)
     
     def list_by_dex(
         self, 
@@ -309,13 +302,18 @@ class PoolsAPI(BaseAPI):
         txns_24h_min: Optional[int] = None,
         created_after: Optional[Union[int, str]] = None,
         created_before: Optional[Union[int, str]] = None,
-    ) -> PoolFilterResponse:
+        cursor: Optional[str] = None,
+    ) -> PoolSearchResponse:
         """
         Filter pools on a network by volume, liquidity, transactions, and creation date.
 
+        Backed by /networks/{network}/pools/search. Legacy sort-field values and
+        filter param names are mapped to the canonical search names automatically.
+
         Args:
             network_id: Network ID (e.g., "ethereum", "solana")
-            page: Page number for pagination (1-indexed)
+            page: Accepted for backward compatibility. The search endpoint is
+                cursor-paginated, so this value is ignored for the request.
             limit: Number of items per page (max 100)
             sort_by: Field to sort by (e.g., "volume_24h", "liquidity_usd", "txns_24h", "created_at")
             sort_dir: Sort direction ("asc" or "desc")
@@ -328,9 +326,10 @@ class PoolsAPI(BaseAPI):
             txns_24h_min: Minimum number of transactions in 24h
             created_after: Only pools created after this time (Unix timestamp)
             created_before: Only pools created before this time (Unix timestamp)
+            cursor: Cursor for cursor-based pagination
 
         Returns:
-            Filtered pools with pagination info
+            Cursor-paginated pool search response
 
         Raises:
             ValueError: If any parameter is invalid
@@ -340,11 +339,15 @@ class PoolsAPI(BaseAPI):
         self._validate_range("limit", limit, min_val=1, max_val=100)
         self._validate_enum("sort_dir", sort_dir, self.VALID_SORT_VALUES)
 
+        # Sort + pagination, using canonical search param names.
         params = {
-            "page": page,
             "limit": limit,
-            "sort_by": sort_by,
-            "sort_dir": sort_dir,
+            "order_by": map_pool_sort_field(sort_by),
+            "sort": sort_dir,
+            "cursor": cursor,
+        }
+        # Filter params, renamed from legacy to canonical search names.
+        filters = {
             "volume_24h_min": volume_24h_min,
             "volume_24h_max": volume_24h_max,
             "volume_7d_min": volume_7d_min,
@@ -355,11 +358,12 @@ class PoolsAPI(BaseAPI):
             "created_after": created_after,
             "created_before": created_before,
         }
+        params.update(map_filter_params(filters, POOL_FILTER_PARAM_MAP))
         params = self._clean_params(params)
 
-        data = self._get(f"/networks/{network_id}/pools/filter", params=params)
+        data = self._get(f"/networks/{network_id}/pools/search", params=params)
 
         if 'results' not in data:
             data['results'] = []
 
-        return PoolFilterResponse(**data)
+        return PoolSearchResponse(**data)

--- a/dexpaprika_sdk/api/tokens.py
+++ b/dexpaprika_sdk/api/tokens.py
@@ -1,8 +1,8 @@
 from typing import Optional, Dict, Any, Set, List, Union
 
-from .base import BaseAPI
+from .base import BaseAPI, map_token_sort_field, map_filter_params, TOKEN_FILTER_PARAM_MAP
 from ..models.tokens import (
-    TokenDetails, TopTokensResponse, TokenFilterResponse, TokenPrice,
+    TokenDetails, TokenSearchResponse, TokenPrice,
 )
 from ..models.pools import PoolsResponse
 from ..utils.perf import track_perf
@@ -104,19 +104,27 @@ class TokensAPI(BaseAPI):
         limit: int = 10,
         order_by: str = "volume_24h",
         sort: str = "desc",
-    ) -> TopTokensResponse:
+        cursor: Optional[str] = None,
+    ) -> TokenSearchResponse:
         """
-        Get top tokens on a network ranked by volume, price, liquidity, or other metrics.
+        Get top tokens on a network ranked by volume, liquidity, or other metrics.
+
+        Backed by /networks/{network}/tokens/search. Legacy sort-field values are
+        mapped to the canonical search names automatically.
 
         Args:
             network_id: Network ID (e.g., "ethereum", "solana")
-            page: Page number for pagination (1-indexed)
+            page: Accepted for backward compatibility. The search endpoint is
+                cursor-paginated, so this value is ignored for the request.
             limit: Number of items per page (max 100)
-            order_by: Field to order by (e.g., "volume_24h", "price_usd", "liquidity_usd", "txns_24h")
+            order_by: Field to order by (e.g., "volume_24h", "liquidity_usd", "txns_24h").
+                Note: tokens/search cannot order by price; "price_usd" falls back
+                to volume_usd_24h.
             sort: Sort direction ("asc" or "desc")
+            cursor: Cursor for cursor-based pagination
 
         Returns:
-            Top tokens with pagination info
+            Cursor-paginated token search response
 
         Raises:
             ValueError: If any parameter is invalid
@@ -127,19 +135,19 @@ class TokensAPI(BaseAPI):
         self._validate_enum("sort", sort, self.VALID_SORT_VALUES)
 
         params = {
-            "page": page,
             "limit": limit,
-            "order_by": order_by,
+            "order_by": map_token_sort_field(order_by),
             "sort": sort,
+            "cursor": cursor,
         }
         params = self._clean_params(params)
 
-        data = self._get(f"/networks/{network_id}/tokens/top", params=params)
+        data = self._get(f"/networks/{network_id}/tokens/search", params=params)
 
-        if 'tokens' not in data:
-            data['tokens'] = []
+        if 'results' not in data:
+            data['results'] = []
 
-        return TopTokensResponse(**data)
+        return TokenSearchResponse(**data)
 
     @track_perf
     def filter(
@@ -157,13 +165,18 @@ class TokensAPI(BaseAPI):
         txns_24h_min: Optional[int] = None,
         created_after: Optional[Union[int, str]] = None,
         created_before: Optional[Union[int, str]] = None,
-    ) -> TokenFilterResponse:
+        cursor: Optional[str] = None,
+    ) -> TokenSearchResponse:
         """
         Filter tokens on a network by volume, liquidity, FDV, transactions, and creation date.
 
+        Backed by /networks/{network}/tokens/search. Legacy sort-field values and
+        filter param names are mapped to the canonical search names automatically.
+
         Args:
             network_id: Network ID (e.g., "ethereum", "solana")
-            page: Page number for pagination (1-indexed)
+            page: Accepted for backward compatibility. The search endpoint is
+                cursor-paginated, so this value is ignored for the request.
             limit: Number of items per page (max 100)
             sort_by: Field to sort by (e.g., "volume_24h", "liquidity_usd", "fdv", "txns_24h")
             sort_dir: Sort direction ("asc" or "desc")
@@ -175,9 +188,10 @@ class TokensAPI(BaseAPI):
             txns_24h_min: Minimum number of transactions in 24h
             created_after: Only tokens created after this time (Unix timestamp)
             created_before: Only tokens created before this time (Unix timestamp)
+            cursor: Cursor for cursor-based pagination
 
         Returns:
-            Filtered tokens with pagination info
+            Cursor-paginated token search response
 
         Raises:
             ValueError: If any parameter is invalid
@@ -187,11 +201,15 @@ class TokensAPI(BaseAPI):
         self._validate_range("limit", limit, min_val=1, max_val=100)
         self._validate_enum("sort_dir", sort_dir, self.VALID_SORT_VALUES)
 
+        # Sort + pagination, using canonical search param names.
         params = {
-            "page": page,
             "limit": limit,
-            "sort_by": sort_by,
-            "sort_dir": sort_dir,
+            "order_by": map_token_sort_field(sort_by),
+            "sort": sort_dir,
+            "cursor": cursor,
+        }
+        # Filter params, renamed from legacy to canonical search names.
+        filters = {
             "volume_24h_min": volume_24h_min,
             "volume_24h_max": volume_24h_max,
             "liquidity_usd_min": liquidity_usd_min,
@@ -201,17 +219,15 @@ class TokensAPI(BaseAPI):
             "created_after": created_after,
             "created_before": created_before,
         }
+        params.update(map_filter_params(filters, TOKEN_FILTER_PARAM_MAP))
         params = self._clean_params(params)
 
-        data = self._get(f"/networks/{network_id}/tokens/filter", params=params)
+        data = self._get(f"/networks/{network_id}/tokens/search", params=params)
 
-        # The token filter endpoint returns rows under a "data" key, not "results".
-        # Map it across (falling back to an empty list) so callers get a consistent
-        # ``results`` field regardless of the wire key.
         if 'results' not in data:
-            data['results'] = data.get('data', [])
+            data['results'] = []
 
-        return TokenFilterResponse(**data)
+        return TokenSearchResponse(**data)
 
     @track_perf
     def get_multi_prices(

--- a/dexpaprika_sdk/client.py
+++ b/dexpaprika_sdk/client.py
@@ -19,7 +19,7 @@ class DexPaprikaClient:
         self,
         base_url: str = "https://api.dexpaprika.com",
         session: Optional[requests.Session] = None,
-        user_agent: str = "DexPaprika-SDK-Python/0.4.0",
+        user_agent: str = "DexPaprika-SDK-Python/0.5.0",
         max_retries: int = 4,
         backoff_times: List[float] = None,
     ):

--- a/dexpaprika_sdk/models/__init__.py
+++ b/dexpaprika_sdk/models/__init__.py
@@ -3,11 +3,14 @@ from .networks import Network, Dex, DexesResponse
 from .pools import (
     Token, Pool, PoolsResponse, TimeIntervalMetrics,
     PoolDetails, OHLCVRecord, Transaction, TransactionsResponse,
+    PoolSearchToken, PoolSearchResult, PoolSearchResponse,
     FilteredPool, PoolFilterResponse,
 )
 from .tokens import (
-    TokenSummary, TokenDetails, TopTokenTimeMetrics, TopToken,
-    TopTokensResponse, FilteredToken, TokenFilterResponse, TokenPrice,
+    TokenSummary, TokenDetails,
+    TokenSearchResult, TokenSearchResponse,
+    TopToken, TopTokensResponse, FilteredToken, TokenFilterResponse,
+    TokenPrice,
 )
 from .search import DexInfo, SearchResult
 from .utils import Stats
@@ -22,12 +25,16 @@ __all__ = [
     # Pools
     "Token", "Pool", "PoolsResponse", "TimeIntervalMetrics",
     "PoolDetails", "OHLCVRecord", "Transaction", "TransactionsResponse",
+    "PoolSearchToken", "PoolSearchResult", "PoolSearchResponse",
+    # Back-compat aliases for the removed /pools(/filter) shapes
     "FilteredPool", "PoolFilterResponse",
 
     # Tokens
     "TokenSummary", "TokenDetails",
-    "TopTokenTimeMetrics", "TopToken", "TopTokensResponse",
-    "FilteredToken", "TokenFilterResponse", "TokenPrice",
+    "TokenSearchResult", "TokenSearchResponse",
+    # Back-compat aliases for the removed tokens/top and tokens/filter shapes
+    "TopToken", "TopTokensResponse", "FilteredToken", "TokenFilterResponse",
+    "TokenPrice",
 
     # Search
     "DexInfo", "SearchResult",

--- a/dexpaprika_sdk/models/pools.py
+++ b/dexpaprika_sdk/models/pools.py
@@ -121,34 +121,66 @@ class TransactionsResponse(PaginatedResponse[Transaction]):
     transactions: List[Transaction] = Field(...)
 
 
-class FilteredPool(BaseModel):
-    """Pool data from the pool filter endpoint (/networks/{id}/pools/filter).
+class PoolSearchToken(BaseModel):
+    """Lightweight token reference returned inside /pools/search results.
 
-    The filter endpoint returns a different shape than the pools list: volume is
-    broken out by timeframe (volume_usd_24h / _7d / _30d) and liquidity_usd is
-    included, instead of the single flat ``volume_usd`` the list endpoint returns.
-    Metric fields are optional so a future shape tweak can't break deserialization.
+    The search endpoint only returns id, name and symbol per token (not the full
+    Token model used by the still-valid list/detail endpoints).
     """
 
     id: str = Field(...)
-    dex_id: str = Field(...)
-    dex_name: str = Field(...)
+    name: Optional[str] = Field(None)
+    symbol: Optional[str] = Field(None)
+
+
+class PoolSearchResult(BaseModel):
+    """A pool item from the unified /networks/{network}/pools/search endpoint.
+
+    Replaces the old pools-list and pools/filter shapes. ``id`` is the pool
+    address, volume is broken out by timeframe, transactions is
+    ``transactions_24h`` and price changes are percentages. Metric fields are
+    optional so a future shape tweak can't break deserialization.
+    """
+
+    id: str = Field(...)  # pool address
     chain: str = Field(...)
-    tokens: List[Token] = Field(...)
+    dex_id: Optional[str] = Field(None)
+    dex_name: Optional[str] = Field(None)
+    fee: Optional[float] = Field(None)
     created_at: Optional[str] = Field(None)
     created_at_block_number: Optional[int] = Field(None)
-    transactions: Optional[int] = Field(None)
-    price_usd: Optional[float] = Field(None)
     volume_usd_24h: Optional[float] = Field(None)
     volume_usd_7d: Optional[float] = Field(None)
     volume_usd_30d: Optional[float] = Field(None)
     liquidity_usd: Optional[float] = Field(None)
-    last_price_change_usd_5m: Optional[float] = Field(None)
-    last_price_change_usd_1h: Optional[float] = Field(None)
-    last_price_change_usd_24h: Optional[float] = Field(None)
-    fee: Optional[float] = Field(None)
+    transactions_24h: Optional[int] = Field(None)
+    price_usd: Optional[float] = Field(None)
+    price_change_percentage_5m: Optional[float] = Field(None)
+    price_change_percentage_1h: Optional[float] = Field(None)
+    price_change_percentage_24h: Optional[float] = Field(None)
+    tokens: List[PoolSearchToken] = Field(default_factory=list)
 
 
-class PoolFilterResponse(PaginatedResponse[FilteredPool]):
-    # pool filter response (uses 'results' key)
-    results: List[FilteredPool] = Field(...)
+class PoolSearchResponse(BaseModel):
+    """Cursor-paginated response from /networks/{network}/pools/search.
+
+    The search endpoints are cursor-based: there is no ``page_info``. Rows are
+    under ``results`` with ``has_next_page`` / ``next_cursor`` for pagination.
+    """
+
+    results: List[PoolSearchResult] = Field(default_factory=list)
+    has_next_page: bool = Field(False)
+    next_cursor: Optional[str] = Field(None)
+    query: Optional[Dict[str, Any]] = Field(None)
+
+    @property
+    def pools(self) -> List[PoolSearchResult]:
+        """Backward-compatible accessor: the old list endpoints returned rows
+        under ``pools``. The search endpoint returns them under ``results``."""
+        return self.results
+
+
+# Backward-compatible aliases. These names referred to the now-removed /pools
+# and /pools/filter response shapes; they now point at the unified search models.
+FilteredPool = PoolSearchResult
+PoolFilterResponse = PoolSearchResponse

--- a/dexpaprika_sdk/models/tokens.py
+++ b/dexpaprika_sdk/models/tokens.py
@@ -67,48 +67,18 @@ class TokenDetailsLight(BaseModel):
     status: Optional[str] = Field(None, description="Token status")
 
 
-class TopTokenTimeMetrics(BaseModel):
-    """Time interval metrics for top tokens (lighter than full TimeIntervalMetrics)."""
+class TokenSearchResult(BaseModel):
+    """A token item from the unified /networks/{network}/tokens/search endpoint.
 
-    volume_usd: float = Field(...)
-    txns: int = Field(...)
-    last_price_usd_change: Optional[float] = Field(None)
-    buys: Optional[int] = Field(None)
-    sells: Optional[int] = Field(None)
-
-
-class TopToken(BaseModel):
-    """Token data from the top tokens endpoint."""
+    Replaces the old tokens/top and tokens/filter shapes, which had nested time
+    metrics and name/symbol. The search shape is flat and identifies a token by
+    ``address``; there is no name, symbol, pools count or buys/sells. Metric
+    fields are optional so a future shape tweak can't break deserialization.
+    """
 
     address: str = Field(...)
-    name: str = Field(...)
-    symbol: str = Field(...)
     chain: str = Field(...)
-    decimals: int = Field(...)
-    has_image: Optional[bool] = Field(None)
-    price_usd: Optional[float] = Field(None)
-    fdv: Optional[float] = Field(None)
-    liquidity_usd: Optional[float] = Field(None)
-    pools: Optional[int] = Field(None)
-
-    # Time interval metrics
-    day: Optional[TopTokenTimeMetrics] = Field(None, alias="24h")
-    hour1: Optional[TopTokenTimeMetrics] = Field(None, alias="1h")
-    minute5: Optional[TopTokenTimeMetrics] = Field(None, alias="5m")
-
-    model_config = ConfigDict(populate_by_name=True)
-
-
-class TopTokensResponse(PaginatedResponse):
-    """Response from the top tokens endpoint."""
-    tokens: List[TopToken] = Field(...)
-
-
-class FilteredToken(BaseModel):
-    """Token data from the token filter endpoint."""
-
-    chain: str = Field(...)
-    address: str = Field(...)
+    created_at: Optional[str] = Field(None)
     price_usd: Optional[float] = Field(None)
     volume_usd_24h: Optional[float] = Field(None)
     volume_usd_7d: Optional[float] = Field(None)
@@ -116,12 +86,37 @@ class FilteredToken(BaseModel):
     liquidity_usd: Optional[float] = Field(None)
     fdv_usd: Optional[float] = Field(None)
     txns_24h: Optional[int] = Field(None)
-    created_at: Optional[str] = Field(None)
+    price_change_percentage_24h: Optional[float] = Field(None)
 
 
-class TokenFilterResponse(PaginatedResponse):
-    """Response from the token filter endpoint."""
-    results: List[FilteredToken] = Field(...)
+class TokenSearchResponse(BaseModel):
+    """Cursor-paginated response from /networks/{network}/tokens/search.
+
+    The search endpoints are cursor-based: there is no ``page_info``. Rows are
+    under ``results`` with ``has_next_page`` / ``next_cursor`` for pagination.
+    """
+
+    results: List[TokenSearchResult] = Field(default_factory=list)
+    has_next_page: bool = Field(False)
+    next_cursor: Optional[str] = Field(None)
+    query: Optional[Dict[str, Any]] = Field(None)
+
+    @property
+    def tokens(self) -> List[TokenSearchResult]:
+        """Backward-compatible accessor: the old top-tokens endpoint returned
+        rows under ``tokens``. The search endpoint returns them under
+        ``results``."""
+        return self.results
+
+
+# Backward-compatible aliases. These names referred to the now-removed
+# tokens/top and tokens/filter shapes; they now point at the unified search
+# models. (TopTokenTimeMetrics was removed: the flat search shape has no nested
+# time-interval objects.)
+FilteredToken = TokenSearchResult
+TokenFilterResponse = TokenSearchResponse
+TopToken = TokenSearchResult
+TopTokensResponse = TokenSearchResponse
 
 
 class TokenPrice(BaseModel):

--- a/examples/advanced_example.py
+++ b/examples/advanced_example.py
@@ -71,11 +71,11 @@ def main():
     # Get pools on this network
     print(f"Getting top pools on {network_id}...")
     try:
-        pools = client.pools.list_by_network(network_id=network_id, limit=5, order_by="volume_usd", sort="desc")
-        print(f"Top 5 pools by volume:")
-        for pool in pools.pools:
+        pools = client.pools.list_by_network(network_id=network_id, limit=5, order_by="volume_usd_24h", sort="desc")
+        print(f"Top 5 pools by 24h volume:")
+        for pool in pools.results:
             token_pair = f"{pool.tokens[0].symbol}/{pool.tokens[1].symbol}" if len(pool.tokens) >= 2 else "Unknown Pair"
-            print(f"- {token_pair} on {pool.dex_name}: {format_currency(pool.volume_usd)} volume ({format_currency(pool.price_usd)} price)")
+            print(f"- {token_pair} on {pool.dex_name}: {format_currency(pool.volume_usd_24h or 0)} volume ({format_currency(pool.price_usd or 0)} price)")
         print()
     except Exception as e:
         print(f"Could not get pools: {e}\n")
@@ -103,9 +103,9 @@ def main():
         print()
     
     # Choose a pool for detailed analysis
-    if pools and pools.pools:
-        pool_address = pools.pools[0].id
-        pool_pair = f"{pools.pools[0].tokens[0].symbol}/{pools.pools[0].tokens[1].symbol}" if len(pools.pools[0].tokens) >= 2 else "Unknown Pair"
+    if pools and pools.results:
+        pool_address = pools.results[0].id
+        pool_pair = f"{pools.results[0].tokens[0].symbol}/{pools.results[0].tokens[1].symbol}" if len(pools.results[0].tokens) >= 2 else "Unknown Pair"
         print(f"Getting detailed info for {pool_pair} pool...")
         
         # Get pool details

--- a/examples/basic_example.py
+++ b/examples/basic_example.py
@@ -31,12 +31,12 @@ def main():
 
     print("\n--------\n")
 
-    # Get top pools
-    pools_resp = client.pools.list(limit=5, order_by="volume_usd", sort="desc")
-    print("Top 5 pools by volume:")
-    for pool in pools_resp.pools:
+    # Get top pools on a network (the global pools list was removed; use a network)
+    pools_resp = client.pools.list_by_network("ethereum", limit=5, order_by="volume_usd_24h", sort="desc")
+    print("Top 5 Ethereum pools by 24h volume:")
+    for pool in pools_resp.results:
         token_pair = f"{pool.tokens[0].symbol}/{pool.tokens[1].symbol}" if len(pool.tokens) >= 2 else "Unknown Pair"
-        print(f"- {token_pair} on {pool.dex_name} ({pool.chain}): ${pool.volume_usd:.2f} volume")
+        print(f"- {token_pair} on {pool.dex_name} ({pool.chain}): ${pool.volume_usd_24h or 0:,.2f} volume")
 
     print("\n--------\n")
 

--- a/tests/test_all_endpoints.py
+++ b/tests/test_all_endpoints.py
@@ -56,8 +56,12 @@ def test_pools_list_deprecated(client):
         warnings.simplefilter("always")
         pools_response = client.pools.list(limit=5)
         assert pools_response is not None
-        assert hasattr(pools_response, 'pools')
-        assert len(pools_response.pools) > 0
+        # The unified search response exposes rows under `results`
+        assert hasattr(pools_response, 'results')
+        assert hasattr(pools_response, 'has_next_page')
+        assert len(pools_response.results) > 0
+        # `pools` remains as a backward-compatible alias for `results`
+        assert pools_response.pools == pools_response.results
         # Check that a deprecation warning was issued
         assert len(w) > 0
         assert any("deprecated" in str(warning.message).lower() for warning in w)
@@ -66,8 +70,13 @@ def test_pools_list_by_network_primary(client, test_data):
     """Test the primary pools list method using network-specific endpoint."""
     pools_response = client.pools.list_by_network(test_data["ethereum_network"], limit=5)
     assert pools_response is not None
-    assert hasattr(pools_response, 'pools')
-    assert len(pools_response.pools) > 0
+    assert hasattr(pools_response, 'results')
+    assert len(pools_response.results) > 0
+    # New search item shape: pool address under `id`, timeframe-split volume
+    pool = pools_response.results[0]
+    assert hasattr(pool, 'id')
+    assert hasattr(pool, 'volume_usd_24h')
+    assert hasattr(pool, 'transactions_24h')
 
 def test_dexes_list(client, test_data):
     dexes_response = client.dexes.list(test_data["ethereum_network"])
@@ -151,12 +160,14 @@ def test_pools_filter(client, test_data):
     )
     assert filtered is not None
     assert hasattr(filtered, 'results')
-    assert hasattr(filtered, 'page_info')
+    # Cursor-based pagination: has_next_page / next_cursor, not page_info
+    assert hasattr(filtered, 'has_next_page')
+    assert hasattr(filtered, 'next_cursor')
     assert len(filtered.results) > 0
     # Verify each pool has the expected fields
     pool = filtered.results[0]
     assert hasattr(pool, 'id')
-    # The filter endpoint returns timeframe-split volume, not a flat volume_usd
+    # The search endpoint returns timeframe-split volume, not a flat volume_usd
     assert hasattr(pool, 'volume_usd_24h')
     assert hasattr(pool, 'tokens')
 
@@ -178,15 +189,18 @@ def test_tokens_get_top(client, test_data):
     """Test getting top tokens on a network."""
     top_tokens = client.tokens.get_top(test_data["ethereum_network"], limit=5)
     assert top_tokens is not None
-    assert hasattr(top_tokens, 'tokens')
-    assert hasattr(top_tokens, 'page_info')
-    assert len(top_tokens.tokens) > 0
-    # Verify token structure
-    token = top_tokens.tokens[0]
+    # Unified search response: rows under `results`, cursor pagination
+    assert hasattr(top_tokens, 'results')
+    assert hasattr(top_tokens, 'has_next_page')
+    assert len(top_tokens.results) > 0
+    # New flat token search item: identified by address, no name/symbol
+    token = top_tokens.results[0]
     assert hasattr(token, 'address')
-    assert hasattr(token, 'name')
-    assert hasattr(token, 'symbol')
+    assert hasattr(token, 'chain')
     assert hasattr(token, 'price_usd')
+    assert hasattr(token, 'volume_usd_24h')
+    # `tokens` remains as a backward-compatible alias for `results`
+    assert top_tokens.tokens == top_tokens.results
 
 def test_tokens_get_top_with_sort(client, test_data):
     """Test getting top tokens with custom sorting."""
@@ -197,7 +211,7 @@ def test_tokens_get_top_with_sort(client, test_data):
         limit=3
     )
     assert top_tokens is not None
-    assert hasattr(top_tokens, 'tokens')
+    assert hasattr(top_tokens, 'results')
 
 # Token Filter API tests
 def test_tokens_filter(client, test_data):
@@ -209,7 +223,9 @@ def test_tokens_filter(client, test_data):
     )
     assert filtered is not None
     assert hasattr(filtered, 'results')
-    assert hasattr(filtered, 'page_info')
+    # Cursor-based pagination: has_next_page / next_cursor, not page_info
+    assert hasattr(filtered, 'has_next_page')
+    assert hasattr(filtered, 'next_cursor')
     assert len(filtered.results) > 0
     # Verify token structure
     token = filtered.results[0]

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -36,12 +36,12 @@ class TestParameterValidation(unittest.TestCase):
         with self.assertRaises(ValueError) as context:
             self.client.pools.list_by_network("ethereum", sort="invalid")
         self.assertIn("sort must be one of: asc, desc", str(context.exception))
-        
-        # Test invalid order_by
-        with self.assertRaises(ValueError) as context:
-            self.client.pools.list_by_network("ethereum", order_by="invalid")
-        self.assertIn("order_by must be one of:", str(context.exception))
-        
+
+        # Note: order_by is no longer validated against a fixed enum. The unified
+        # /pools/search and /tokens/search endpoints 400 on legacy sort fields, so
+        # the SDK maps known legacy values to canonical ones and falls back to a
+        # sensible default for anything unknown (rather than raising).
+
         # Test invalid interval
         with self.assertRaises(ValueError) as context:
             self.client.pools.get_ohlcv(


### PR DESCRIPTION
DexPaprika removed four REST endpoints (HTTP 410): `/networks/{network}/pools`, `/networks/{network}/pools/filter`, `/networks/{network}/tokens/top`, `/networks/{network}/tokens/filter`. The network-pools, pool-filter, top-tokens, and token-filter methods were erroring.

## Fix

Repoint all four to the unified search endpoints (method names + signatures unchanged for back-compat):

- network pools, pool filter -> `/networks/{network}/pools/search`
- top tokens, token filter -> `/networks/{network}/tokens/search`

A shared helper normalizes legacy sort-field values (`volume_usd` -> `volume_usd_24h`, `transactions` -> `txns_24h`, `last_price_change_usd_24h` -> `price_change_percentage_24h`, ...) and legacy filter param names (`volume_24h_min` -> `volume_usd_24h_min`, ...). The search endpoints **400** on the old names, so this mapping is required; the filter methods now send `order_by` + `sort`. Token sort by price falls back to volume (the token search rejects price ordering).

Responses are cursor-paginated: rows under `results` with `has_next_page` + `next_cursor` (no `page_info`); models use the new field names (`id` not `address` for pools, `transactions_24h`, `price_change_percentage_24h`, `fdv_usd`, ...). The new flat token shape has no name/symbol/buys/sells, so token models reflect what the API returns. Legacy params are still accepted; `page` is kept in signatures but no longer sent (an optional `cursor` is added).

## Verified

Live against api.dexpaprika.com: build and test suite pass; all four methods return real rows in both default and JSON usage; legacy sort values map instead of 400; zero em/en dashes.

## Release

After merge: build + upload to PyPI (`python -m build && twine upload dist/*`), v0.5.0. The pre-existing deprecated global `/pools` list method is intentionally left to surface its deprecation (out of scope).