### PR TITLE
Add typed DeprecatedEndpointError surfacing the replacement (0.5.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to the DexPaprika SDK for Python will be documented in this 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.1] - 2026-07-01
+
+### Added
+- **`DeprecatedEndpointError`**: when the API returns an error whose body carries a `replacement` field, the client now raises this typed exception (subclass of `DexPaprikaError`) with the API message + `Use <replacement> instead.`, and `.replacement` / `.api_message` / `.status_code` accessors, instead of a bare `requests.HTTPError`. Not retried. Generic across any error status carrying a `replacement`.
+
 ## [0.5.0] - 2026-06-30
 
 ### Breaking Changes

--- a/dexpaprika_sdk/__init__.py
+++ b/dexpaprika_sdk/__init__.py
@@ -11,6 +11,7 @@ across multiple blockchain networks.
 """
 
 from .client import DexPaprikaClient
+from .exceptions import DexPaprikaError, DeprecatedEndpointError
 # Import models for easier access
 from .models import (
     Network, Dex, DexesResponse,
@@ -26,9 +27,11 @@ from .models import (
     Stats
 )
 
-__version__ = "0.5.0"
+__version__ = "0.5.1"
 __all__ = [
     "DexPaprikaClient",
+    # Exceptions
+    "DexPaprikaError", "DeprecatedEndpointError",
     # Models
     "Network", "Dex", "DexesResponse",
     "Token", "Pool", "PoolsResponse", "TimeIntervalMetrics",

--- a/dexpaprika_sdk/client.py
+++ b/dexpaprika_sdk/client.py
@@ -10,6 +10,7 @@ from .api.tokens import TokensAPI
 from .api.search import SearchAPI
 from .api.utils import UtilsAPI
 from .api.dexes import DexesAPI
+from .exceptions import DeprecatedEndpointError
 
 
 class DexPaprikaClient:
@@ -19,7 +20,7 @@ class DexPaprikaClient:
         self,
         base_url: str = "https://api.dexpaprika.com",
         session: Optional[requests.Session] = None,
-        user_agent: str = "DexPaprika-SDK-Python/0.5.0",
+        user_agent: str = "DexPaprika-SDK-Python/0.5.1",
         max_retries: int = 4,
         backoff_times: List[float] = None,
     ):
@@ -47,13 +48,55 @@ class DexPaprikaClient:
         Returns:
             True if the request should be retried, False otherwise
         """
-        if isinstance(exception, (ConnectionError, Timeout)):
+        if isinstance(exception, DeprecatedEndpointError):
+            # A deprecation hint is deterministic; retrying will never help.
+            return False
+        elif isinstance(exception, (ConnectionError, Timeout)):
             # Always retry connection errors and timeouts
             return True
         elif isinstance(exception, HTTPError):
             # Retry server errors (5xx) but not client errors (4xx)
             return 500 <= exception.response.status_code < 600
         return False
+
+    def _deprecation_error(self, response) -> Optional[DeprecatedEndpointError]:
+        """Build a DeprecatedEndpointError if the error body carries a replacement.
+
+        The API self-documents removed endpoints by returning a non-2xx response
+        whose JSON body includes a "replacement" field. This keys on the presence
+        of that field for ANY error status, so future deprecations surface the
+        same way without hardcoding endpoints or status codes.
+
+        Defensive by design: the body may not be JSON, may not be an object, or
+        may lack "replacement". In any of those cases this returns None so the
+        caller falls back to the current ``raise_for_status`` behavior.
+
+        Args:
+            response: The ``requests.Response`` for a non-2xx request.
+
+        Returns:
+            A DeprecatedEndpointError when a replacement hint is present, else None.
+        """
+        try:
+            body = response.json()
+        except Exception:
+            # Not JSON (or unreadable body): fall back to default handling.
+            return None
+
+        if not isinstance(body, dict):
+            return None
+
+        replacement = body.get("replacement")
+        if not replacement:
+            return None
+
+        message = body.get("message") or "endpoint removed"
+        return DeprecatedEndpointError(
+            message=message,
+            replacement=replacement,
+            status_code=getattr(response, "status_code", None),
+            response=response,
+        )
 
     def request(
         self,
@@ -80,7 +123,15 @@ class DexPaprikaClient:
                     method=method, url=url, params=params, json=data, headers=request_headers,
                 )
 
-                # err check
+                # err check: surface the API's deprecation hint (a "replacement"
+                # field on an error body) as a typed error before the generic
+                # HTTPError. Guarded on a real error status so mocked responses
+                # and success responses are untouched.
+                status_code = getattr(response, "status_code", None)
+                if isinstance(status_code, int) and status_code >= 400:
+                    deprecation = self._deprecation_error(response)
+                    if deprecation is not None:
+                        raise deprecation
                 response.raise_for_status()
 
                 # return data

--- a/dexpaprika_sdk/exceptions.py
+++ b/dexpaprika_sdk/exceptions.py
@@ -1,0 +1,44 @@
+"""
+Typed exceptions for the DexPaprika SDK.
+
+The API self-documents deprecations: when an endpoint is removed or deprecated
+it returns a non-2xx response whose JSON body carries a "replacement" field
+pointing at the endpoint to use instead, for example::
+
+    {"code": 410, "message": "endpoint removed",
+     "replacement": "/networks/:network/pools/search"}
+
+The client turns any such response into a ``DeprecatedEndpointError`` so that
+callers (and their logs) see both the API's own message and the replacement
+without having to inspect the raw response body.
+"""
+
+
+class DexPaprikaError(Exception):
+    """Base class for all typed errors raised by the DexPaprika SDK."""
+
+
+class DeprecatedEndpointError(DexPaprikaError):
+    """Raised when an error response carries a "replacement" deprecation hint.
+
+    This is generic: it fires for any error status whose body contains a
+    "replacement" field, not just HTTP 410, so future deprecations surface
+    the same way without SDK changes.
+
+    Attributes:
+        replacement: The endpoint path the API tells you to use instead.
+        api_message: The raw "message" value from the response body.
+        status_code: The HTTP status code of the error response, if known.
+        response: The underlying ``requests.Response``, if available.
+    """
+
+    def __init__(self, message, replacement, status_code=None, response=None):
+        self.api_message = message
+        self.replacement = replacement
+        self.status_code = status_code
+        self.response = response
+
+        full_message = message or "endpoint removed"
+        if replacement:
+            full_message = f"{full_message}. Use {replacement} instead."
+        super().__init__(full_message)

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -5,12 +5,14 @@ Test script to verify caching and retry behavior in the DexPaprika SDK.
 
 import unittest
 import time
+import json
 from datetime import timedelta
 from unittest.mock import patch, MagicMock
 import requests
 from requests.exceptions import ConnectionError, Timeout, HTTPError
 
 from dexpaprika_sdk import DexPaprikaClient
+from dexpaprika_sdk.exceptions import DeprecatedEndpointError, DexPaprikaError
 
 
 class TestCachingBehavior(unittest.TestCase):
@@ -176,6 +178,90 @@ class TestRetryBehavior(unittest.TestCase):
             
             # Should be called 3 times (initial + 2 retries)
             self.assertEqual(mock_request.call_count, 3)
+
+
+class TestDeprecationHandling(unittest.TestCase):
+    """Test suite for the API's self-documenting deprecation hints."""
+
+    def setUp(self):
+        """Set up test environment."""
+        self.client = DexPaprikaClient(max_retries=2, backoff_times=[0.01, 0.02])
+
+    @staticmethod
+    def _error_response(status_code, body):
+        """Build a real requests.Response with a JSON (or raw) error body."""
+        response = requests.Response()
+        response.status_code = status_code
+        if isinstance(body, (dict, list)):
+            response._content = json.dumps(body).encode("utf-8")
+        else:
+            response._content = body.encode("utf-8") if isinstance(body, str) else body
+        return response
+
+    def test_replacement_raises_typed_error(self):
+        """A 410 body with a replacement raises DeprecatedEndpointError."""
+        body = {
+            "code": 410,
+            "message": "endpoint removed",
+            "replacement": "/networks/:network/pools/search",
+        }
+        with patch('requests.Session.request') as mock_request:
+            mock_request.return_value = self._error_response(410, body)
+
+            with self.assertRaises(DeprecatedEndpointError) as ctx:
+                self.client.get("/pools")
+
+            error = ctx.exception
+            # It surfaces both the API message and the replacement.
+            self.assertEqual(error.replacement, "/networks/:network/pools/search")
+            self.assertEqual(error.api_message, "endpoint removed")
+            self.assertEqual(error.status_code, 410)
+            self.assertIn("endpoint removed", str(error))
+            self.assertIn(
+                "Use /networks/:network/pools/search instead.", str(error)
+            )
+            # It is a DexPaprikaError so callers can catch the family.
+            self.assertIsInstance(error, DexPaprikaError)
+
+    def test_replacement_is_not_retried(self):
+        """Deprecation hints are deterministic and must not be retried."""
+        body = {"message": "endpoint removed", "replacement": "/pools/search"}
+        with patch('requests.Session.request') as mock_request:
+            mock_request.return_value = self._error_response(410, body)
+
+            with self.assertRaises(DeprecatedEndpointError):
+                self.client.get("/pools")
+
+            self.assertEqual(mock_request.call_count, 1)
+
+    def test_replacement_generic_across_status_codes(self):
+        """Any error status with a replacement surfaces the typed error."""
+        body = {"message": "moved", "replacement": "/tokens/search"}
+        with patch('requests.Session.request') as mock_request:
+            mock_request.return_value = self._error_response(400, body)
+
+            with self.assertRaises(DeprecatedEndpointError) as ctx:
+                self.client.get("/tokens/top")
+
+            self.assertEqual(ctx.exception.replacement, "/tokens/search")
+            self.assertEqual(ctx.exception.status_code, 400)
+
+    def test_error_without_replacement_falls_back(self):
+        """An error body without a replacement keeps the bare HTTPError behavior."""
+        body = {"code": 410, "message": "endpoint removed"}
+        with patch('requests.Session.request') as mock_request:
+            mock_request.return_value = self._error_response(410, body)
+
+            with self.assertRaises(HTTPError):
+                self.client.get("/pools")
+
+    def test_non_json_error_falls_back(self):
+        """A non-JSON error body keeps the bare HTTPError behavior."""
+        with patch('requests.Session.request') as mock_request:
+            mock_request.return_value = self._error_response(410, "not json at all")
+
+            with self.assertRaises(HTTPError):
+                self.client.get("/pools")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
On an error body carrying a `replacement`, the client now raises a typed `DeprecatedEndpointError` (subclass of `DexPaprikaError`) with the API message + `Use <replacement> instead.` and `.replacement`/`.api_message`/`.status_code` accessors, instead of a bare `requests.HTTPError`. Not retried; generic across statuses; defensive fallback. Version 0.5.1 (0.5.0 was not published). pytest 39 passed. Publish after merge: build + `twine upload`.